### PR TITLE
add release notes to github release in workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,8 +39,13 @@ jobs:
           ./build.sh
           echo "${{ secrets.KEYSTORE }}" | base64 -di > keystore.jks
           apksigner sign --ks keystore.jks --ks-pass pass:${{ secrets.KEYSTORE_PASSPHRASE }} patched_signed.apk
+      - name: Get release notes
+        run: |
+          RELEASE_NOTES=$(curl -s https://gitlab.com/api/v4/projects/ironfox-oss%2FIronFox/releases/v$BUILD_VERSION | jq -r .description | sed '/## Checksums/,/This release was automatically generated/d')
+          echo "$RELEASE_NOTES" >> $GITHUB_ENV
       - name: Publish release
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ env.BUILD_VERSION }}
           files: ${{ github.workspace }}/patched_signed.apk
+          body: ${{ env.RELEASE_NOTES }}


### PR DESCRIPTION
I swapped to https://github.com/handokota/IronFoxMidnight when there was that short lived issue here, but there's been a PR with fixes open in there for a while which has been merged here so I've switched back, **however** I liked the changelog detailed in the releases in that repo, so I've replicated it here.

As the version is being fetched from the fdroid repo here the request is slightly different, in that it gets the specifc release details already set in the `BUILD_VERSION` env var, but it then does the same `sed` logic to filter out the full changelog text with check sums etc to just the `Changes` block.
An example of what the looks like can be seen here: https://github.com/handokota/IronFoxMidnight/releases/tag/v140.0