### PR TITLE
wrap release notes in a heredoc to fix handling of multiline string

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,9 @@ jobs:
       - name: Get release notes
         run: |
           RELEASE_NOTES=$(curl -s https://gitlab.com/api/v4/projects/ironfox-oss%2FIronFox/releases/v$BUILD_VERSION | jq -r .description | sed '/## Checksums/,/This release was automatically generated/d')
+          echo "RELEASE_NOTES<<EOF" >> $GITHUB_ENV
           echo "$RELEASE_NOTES" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
       - name: Publish release
         uses: softprops/action-gh-release@v1
         with:


### PR DESCRIPTION
The releases notes section broke the last build: https://github.com/ArtikusHG/Ironfox-OLEDDark/actions/runs/16157996852/job/45604201650

It doesn't like the handling of the multi line string in the environment variable.
My bad.

Looks like the way GitHub needs this to work is by wrapping it in in a heredoc.