### PR TITLE
Fix build

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,0 +1,19 @@
+name: PR Build Test
+on:
+  pull_request:
+    branches: [main]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install build dependencies
+        run: |
+            sudo apt update
+            sudo apt install -y wget apktool zipalign
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - name: Run build script
+        run: |
+          cd ${{ github.workspace }}
+          chmod +x ./build.sh
+          ./build.sh

--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,7 @@ wget -q https://raw.githubusercontent.com/iBotPeaches/Apktool/master/scripts/lin
 chmod +x apktool*
 
 rm -rf patched patched_signed.apk
-./apktool d latest.apk -o patched 
+./apktool d latest.apk -o patched
 rm -rf patched/META-INF
 
 sed -i 's/<color name="fx_mobile_layer_color_1">.*/<color name="fx_mobile_layer_color_1">#ff000000<\/color>/g' patched/res/values-night/colors.xml
@@ -26,7 +26,7 @@ sed -i 's/eeeeee/e3e3e3/g' patched/assets/extensions/readerview/readerview.css
 sed -i 's/mipmap\/ic_launcher_round/drawable\/ic_launcher_foreground/g' patched/res/drawable-v23/splash_screen.xml
 sed -i 's/160\.0dip/200\.0dip/g' patched/res/drawable-v23/splash_screen.xml
 
-./apktool b patched -o patched.apk --use-aapt2
+./apktool b patched -o patched.apk
 
 zipalign 4 patched.apk patched_signed.apk
 rm -rf patched patched.apk


### PR DESCRIPTION
The last pull request broke the build as it updated the version of apktool without actually testing it worked and one of the arguments used no longer works on the newer version (see the github actions history).

This pull request fixes the build by removing the flag that breaks things now, and adds configuration to run the build script on pull requests, so changes in future can make sure things work before merging.